### PR TITLE
Bitslicing implementation complete

### DIFF
--- a/trivium.go
+++ b/trivium.go
@@ -8,12 +8,14 @@ Trivium is a light weight stream cipher developed to be particularly efficient i
 
 The trivium specification is http://www.ecrypt.eu.org/stream/p3ciphers/trivium/trivium_p3.pdf
 
-This is a straighforward implementation based on the specification
+This is a straighforward implementation based on the specification using SWAR calculations
+to calculate up to 32 bits at a time.
 
 */
 package trivium
 
 import "strconv"
+import "fmt"
 
 // Trivium represents the 288-bit state of the Trivium cipher.
 type Trivium struct {
@@ -43,25 +45,26 @@ const (
 	i69  = 68 >> bitsInWord
 	i94  = 93 >> bitsInWord
 	i178 = 177 >> bitsInWord
-	// the position within the word, shift
-	mask  = (1 << bitsInWord) - 1
-	sh66  = 65 & mask
-	sh93  = 92 & mask
-	sh162 = 161 & mask
-	sh177 = 176 & mask
-	sh243 = 242 & mask
-	sh288 = 287 & mask
-	sh91  = 90 & mask
-	sh92  = 91 & mask
-	sh171 = 170 & mask
-	sh175 = 174 & mask
-	sh176 = 175 & mask
-	sh264 = 263 & mask
-	sh286 = 285 & mask
-	sh287 = 286 & mask
-	sh69  = 68 & mask
-	sh94  = 93 & mask
-	sh178 = 177 & mask
+	// the position within the word, shift within the word starting from the left
+	fullshift = 1 << bitsInWord
+	mask      = fullshift - 1
+	sh66      = mask - (65 & mask)
+	sh93      = mask - (92 & mask)
+	sh162     = mask - (161 & mask)
+	sh177     = mask - (176 & mask)
+	sh243     = mask - (242 & mask)
+	sh288     = mask - (287 & mask)
+	sh91      = mask - (90 & mask)
+	sh92      = mask - (91 & mask)
+	sh171     = mask - (170 & mask)
+	sh175     = mask - (174 & mask)
+	sh176     = mask - (175 & mask)
+	sh264     = mask - (263 & mask)
+	sh286     = mask - (285 & mask)
+	sh287     = mask - (286 & mask)
+	sh69      = mask - (68 & mask)
+	sh94      = mask - (93 & mask)
+	sh178     = mask - (177 & mask)
 )
 
 // NewTrivium returns a Trivium cipher initialized with key and initialization value (IV).
@@ -70,75 +73,142 @@ const (
 func NewTrivium(key, iv [KeyLength]byte) *Trivium {
 	var state [9]uint32
 
-	state[0] = (uint32(key[3]) << 24) | (uint32(key[2]) << 16) | (uint32(key[1]) << 8) | uint32(key[0])
-	state[1] = (uint32(key[7]) << 24) | (uint32(key[6]) << 16) | (uint32(key[5]) << 8) | uint32(key[4])
-	state[2] = (uint32(iv[0]) << 29) | (uint32(key[9]) << 8) | uint32(key[8])
-	state[3] = (uint32(iv[4]) << 29) | (uint32(iv[3]) << 21) | (uint32(iv[2]) << 13) | (uint32(iv[1]) << 5) | (uint32(iv[0]) >> 3)
-	state[4] = (uint32(iv[8]) << 29) | (uint32(iv[7]) << 21) | (uint32(iv[6]) << 13) | (uint32(iv[5]) << 5) | (uint32(iv[4]) >> 3)
-	state[5] = (uint32(iv[9]) << 5) | (uint32(iv[8]) >> 3)
+	state[0] = (uint32(reverseByte(key[0])) << 24) | (uint32(reverseByte(key[1])) << 16) | (uint32(reverseByte(key[2])) << 8) | uint32(reverseByte(key[3]))
+	state[1] = (uint32(reverseByte(key[4])) << 24) | (uint32(reverseByte(key[5])) << 16) | (uint32(reverseByte(key[6])) << 8) | uint32(reverseByte(key[7]))
+	state[2] = (uint32(reverseByte(iv[0])) >> 5) | (uint32(reverseByte(key[8])) << 24) | (uint32(reverseByte(key[9])) << 16)
+	state[3] = (uint32(reverseByte(iv[4])) >> 5) | (uint32(reverseByte(iv[3])) << 3) | (uint32(reverseByte(iv[2])) << 11) | (uint32(reverseByte(iv[1])) << 19) | (uint32(reverseByte(iv[0])) << 27)
+	state[4] = (uint32(reverseByte(iv[8])) >> 5) | (uint32(reverseByte(iv[7])) << 3) | (uint32(reverseByte(iv[6])) << 11) | (uint32(reverseByte(iv[5])) << 19) | (uint32(reverseByte(iv[4])) << 27)
+	state[5] = (uint32(reverseByte(iv[9])) << 19) | (uint32(reverseByte(iv[8])) << 27)
 	// state[6] and state[7] are initialized with all zeros
-	state[8] = uint32(7) << 29
+	state[8] = uint32(7)
+
 	trivium := Trivium{state: state}
 	for i := 0; i < 4*288; i++ {
 		trivium.NextBit()
 	}
+
 	return &trivium
 }
 
 // NextBit gets the next bit from the Trivium stream.
 func (t *Trivium) NextBit() uint32 {
+	return t.NextBits(1)
+}
+
+// NextBits gets the next 1 to 63 bits from the Trivium stream.
+func (t *Trivium) NextBits(n uint) uint32 {
+	var bitmask uint32 = (1 << n) - 1
 	// get the taps
-	t1 := (t.state[i66] >> sh66) ^ (t.state[i93] >> sh93)
-	t2 := (t.state[i162] >> sh162) ^ (t.state[i177] >> sh177)
-	t3 := (t.state[i243] >> sh243) ^ (t.state[i288] >> sh288)
+	s66 := (t.state[i66] >> sh66) | (t.state[i66-1] << (fullshift - sh66))
+	s93 := (t.state[i93] >> sh93) | (t.state[i93-1] << (fullshift - sh93))
+	s162 := (t.state[i162] >> sh162) | (t.state[i162-1] << (fullshift - sh162))
+	s177 := (t.state[i177] >> sh177) | (t.state[i177-1] << (fullshift - sh177))
+	s243 := (t.state[i243] >> sh243) | (t.state[i243-1] << (fullshift - sh243))
+	s288 := (t.state[i288] >> sh288) | (t.state[i288-1] << (fullshift - sh288))
+
+	t1 := s66 ^ s93
+	t2 := s162 ^ s177
+	t3 := s243 ^ s288
 	// store the output
-	z := (t1 ^ t2 ^ t3) & 1
+	z := (t1 ^ t2 ^ t3) & bitmask
 	// process the taps
-	t1 ^= (t.state[i91]>>sh91)&(t.state[i92]>>sh92) ^ (t.state[i171] >> sh171)
-	t2 ^= (t.state[i175]>>sh175)&(t.state[i176]>>sh176) ^ (t.state[i264] >> sh264)
-	t3 ^= (t.state[i286]>>sh286)&(t.state[i287]>>sh287) ^ (t.state[i69] >> sh69)
+	s91 := (t.state[i91] >> sh91) | (t.state[i91-1] << (fullshift - sh91))
+	s92 := (t.state[i92] >> sh92) | (t.state[i92-1] << (fullshift - sh92))
+	s171 := (t.state[i171] >> sh171) | (t.state[i171-1] << (fullshift - sh171))
+	s175 := (t.state[i175] >> sh175) | (t.state[i175-1] << (fullshift - sh175))
+	s176 := (t.state[i176] >> sh176) | (t.state[i176-1] << (fullshift - sh176))
+	s264 := (t.state[i264] >> sh264) | (t.state[i264-1] << (fullshift - sh264))
+	s286 := (t.state[i286] >> sh286) | (t.state[i286-1] << (fullshift - sh286))
+	s287 := (t.state[i287] >> sh287) | (t.state[i287-1] << (fullshift - sh287))
+	s69 := (t.state[i69] >> sh69) | (t.state[i69-1] << (fullshift - sh69))
+
+	t1 ^= ((s91 & s92) ^ s171)
+	t2 ^= ((s175 & s176) ^ s264)
+	t3 ^= ((s286 & s287) ^ s69)
+	t1 &= bitmask
+	t2 &= bitmask
+	t3 &= bitmask
 
 	// rotate the state
-	t.state[8] = (t.state[8] << 1) | (t.state[7] >> 31)
-	t.state[7] = (t.state[7] << 1) | (t.state[6] >> 31)
-	t.state[6] = (t.state[6] << 1) | (t.state[5] >> 31)
-	t.state[5] = (t.state[5] << 1) | (t.state[4] >> 31)
-	t.state[4] = (t.state[4] << 1) | (t.state[3] >> 31)
-	t.state[3] = (t.state[3] << 1) | (t.state[2] >> 31)
-	t.state[2] = (t.state[2] << 1) | (t.state[1] >> 31)
-	t.state[1] = (t.state[1] << 1) | (t.state[0] >> 31)
-	t.state[0] = (t.state[0] << 1) | (t3 & 1)
+	t.state[8] = (t.state[8] >> n) | (t.state[7] << (fullshift - n))
+	t.state[7] = (t.state[7] >> n) | (t.state[6] << (fullshift - n))
+	t.state[6] = (t.state[6] >> n) | (t.state[5] << (fullshift - n))
+	t.state[5] = (t.state[5] >> n) | (t.state[4] << (fullshift - n))
+	t.state[4] = (t.state[4] >> n) | (t.state[3] << (fullshift - n))
+	t.state[3] = (t.state[3] >> n) | (t.state[2] << (fullshift - n))
+	t.state[2] = (t.state[2] >> n) | (t.state[1] << (fullshift - n))
+	t.state[1] = (t.state[1] >> n) | (t.state[0] << (fullshift - n))
+	t.state[0] = (t.state[0] >> n) | (t3 << (fullshift - n))
 	// update the final values
-	t.state[i94] = t.state[i94] &^ (1 << sh94)
-	t.state[i94] |= (t1 & 1) << sh94
-	t.state[i178] = t.state[i178] &^ (1 << sh178)
-	t.state[i178] |= (t2 & 1) << sh178
-	return z
 
+	n94 := 92 + n
+	n178 := 176 + n
+	ni94 := n94 >> bitsInWord
+	nsh94 := mask - (n94 & mask)
+	ni178 := n178 >> bitsInWord
+	nsh178 := mask - (n178 & mask)
+
+	t.state[ni94] = t.state[ni94] &^ (bitmask << nsh94)
+	t.state[ni94] |= t1 << nsh94
+	// need to handle overlap across word boundaries
+	t.state[i94] = t.state[i94] &^ (bitmask >> (fullshift - nsh94))
+	t.state[i94] |= t1 >> (fullshift - nsh94)
+
+	t.state[ni178] = t.state[ni178] &^ (bitmask << nsh178)
+	t.state[ni178] |= t2 << nsh178
+	// need to handle overlap across word boundaries
+	t.state[i178] = t.state[i178] &^ (bitmask >> (fullshift - nsh178))
+	t.state[i178] |= t2 >> (fullshift - nsh178)
+
+	return z
+}
+
+func printWord(word uint32) {
+	buff := make([]byte, 0, fullshift)
+	bits := []byte(strconv.FormatUint(uint64(word), 2))
+	for j := len(bits); j < fullshift; j++ {
+		buff = append(buff, '0') // add any leading zeros
+	}
+	buff = append(buff, bits...) // append the bits
+	fmt.Println(string(buff))
 }
 
 // NextByte returns the next byte of key stream with the MSB as the last bit produced.
 // the first byte produced will have bits [76543210] of the keystream
 func (t *Trivium) NextByte() byte {
-	var keyStreamByte uint32
-	for j := 0; j < 8; j++ {
-		keyStreamByte = (keyStreamByte >> 1) | (t.NextBit() << 7)
+	return byte(t.NextBits(8))
+}
+
+// NextBytes returns the next 1 to 4 bytes of key stream with the MSB as the last bit produced.
+// the first byte produced will have bits [76543210] of the keystream
+func (t *Trivium) NextBytes(n uint) []byte {
+	output := make([]byte, n)
+	word := t.NextBits(n << 3)
+	for i := uint(0); i < n; i++ {
+		output[i] = byte(word >> (i << 3))
 	}
-	return byte(keyStreamByte)
+
+	return output
 }
 
 // String outputs a '0' and '1' representation of the trivium internal state
 // as a binary string with the first bit at the left.
 func (t Trivium) String() string {
-	buff := make([]byte, 0, 32*len(t.state))
+	buff := make([]byte, 0, fullshift*len(t.state))
 	for _, word := range t.state {
 		bits := []byte(strconv.FormatUint(uint64(word), 2))
-		for i := len(bits) - 1; i >= 0; i-- {
-			buff = append(buff, bits[i]) // append the bits in reverse order
-		}
-		for j := len(bits); j < 32; j++ {
+		for j := len(bits); j < fullshift; j++ {
 			buff = append(buff, '0') // add any leading zeros
 		}
+		buff = append(buff, bits...) // append the bits
 	}
 	return string(buff)
+}
+
+// reverseByte reverses the bits in byte
+func reverseByte(b byte) byte {
+	return ((b & 0x1) << 7) | ((b & 0x80) >> 7) |
+		((b & 0x2) << 5) | ((b & 0x40) >> 5) |
+		((b & 0x4) << 3) | ((b & 0x20) >> 3) |
+		((b & 0x8) << 1) | ((b & 0x10) >> 1)
 }

--- a/trivium_test.go
+++ b/trivium_test.go
@@ -37,12 +37,13 @@ func ExampleNewTrivium() {
 }
 
 // the "official" test vectors for 80-bit key and 80-bit IV
-// http://www.ecrypt.eu.org/stream/svn/viewcvs.cgi/*checkout*/ecrypt/trunk/submissions/trivium/unverified.test-vectors?rev=210
+// http://www.ecrypt.eu.org/stream/svn/viewcvs.cgi/checkout/ecrypt/trunk/submissions/trivium/unverified.test-vectors?rev=210
 // https://trac.cryptolib.org/avr-crypto-lib/browser/testvectors/trivium-80.80.test-vectors
 // these appear to load the key and iv incorrectly according to the spec
 // the vectors are big-endian, i.e. most significant byte of key and iv is on the left [9][8]...[1][0]
 // but the bit order is flipped, i.e. 0x80 should be loaded as 0x01 etc.
 // [72,73,74,75,76,77,78,79][64,65,66,67,68,69,70,71]...[8,9,10,11,12,13,14,15][0,1,2,3,4,5,6,7]
+
 const TestVectorFile8080 = "trivium-80.80.test-vectors"
 
 const (
@@ -57,13 +58,6 @@ var (
 	dataRe   = regexp.MustCompile(`([0-9A-F]{32})`)
 	digestRe = regexp.MustCompile(`digest = ([0-9A-F]{20})`)
 )
-
-func reverseByte(b byte) byte {
-	return ((b & 0x1) << 7) | ((b & 0x80) >> 7) |
-		((b & 0x2) << 5) | ((b & 0x40) >> 5) |
-		((b & 0x4) << 3) | ((b & 0x20) >> 3) |
-		((b & 0x8) << 1) | ((b & 0x10) >> 1)
-}
 
 func TestTriviumTestVectors(t *testing.T) {
 	file, err := os.Open(TestVectorFile8080)
@@ -140,20 +134,20 @@ func TestTriviumTestVectors(t *testing.T) {
 				got = append(got, testByte)
 
 			}
-			if reflect.DeepEqual(got, tv) != true {
-				t.Errorf("key: %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X\n", key[9], key[8], key[7], key[6], key[5], key[4], key[3], key[2], key[1], key[0])
-				t.Errorf("iv:  %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X\n", iv[9], iv[8], iv[7], iv[6], iv[5], iv[4], iv[3], iv[2], iv[1], iv[0])
-				t.Errorf("test vector starts at byte: %d", startingByte)
-				t.Errorf("tv:  %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X\n", tv[0], tv[1], tv[2], tv[3], tv[4], tv[5], tv[6], tv[7], tv[8], tv[9], tv[10], tv[11], tv[12], tv[13], tv[14], tv[15])
-				t.Errorf("     %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X\n", tv[16], tv[17], tv[18], tv[19], tv[20], tv[21], tv[22], tv[23], tv[24], tv[25], tv[26], tv[27], tv[28], tv[29], tv[30], tv[31])
-				t.Errorf("     %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X\n", tv[32], tv[33], tv[34], tv[35], tv[36], tv[37], tv[38], tv[39], tv[40], tv[41], tv[42], tv[43], tv[44], tv[45], tv[46], tv[47])
-				t.Errorf("     %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X\n", tv[48], tv[49], tv[50], tv[51], tv[52], tv[53], tv[54], tv[55], tv[56], tv[57], tv[58], tv[59], tv[60], tv[61], tv[62], tv[63])
-				t.Errorf("got: %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X\n", got[0], got[1], got[2], got[3], got[4], got[5], got[6], got[7], got[8], got[9], got[10], got[11], got[12], got[13], got[14], got[15])
-				t.Errorf("     %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X\n", got[16], got[17], got[18], got[19], got[20], got[21], got[22], got[23], got[24], got[25], got[26], got[27], got[28], got[29], got[30], got[31])
-				t.Errorf("     %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X\n", got[32], got[33], got[34], got[35], got[36], got[37], got[38], got[39], got[40], got[41], got[42], got[43], got[44], got[45], got[46], got[47])
-				t.Errorf("     %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X\n", got[48], got[49], got[50], got[51], got[52], got[53], got[54], got[55], got[56], got[57], got[58], got[59], got[60], got[61], got[62], got[63])
-			}
 
+			if reflect.DeepEqual(got, tv) != true {
+				t.Errorf("key:   %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X\n", key[9], key[8], key[7], key[6], key[5], key[4], key[3], key[2], key[1], key[0])
+				t.Errorf("iv:    %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X\n", iv[9], iv[8], iv[7], iv[6], iv[5], iv[4], iv[3], iv[2], iv[1], iv[0])
+				t.Errorf("test vector starts at byte: %d", startingByte)
+				t.Errorf("want:  %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X\n", tv[0], tv[1], tv[2], tv[3], tv[4], tv[5], tv[6], tv[7], tv[8], tv[9], tv[10], tv[11], tv[12], tv[13], tv[14], tv[15])
+				t.Errorf("got:   %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X\n", got[0], got[1], got[2], got[3], got[4], got[5], got[6], got[7], got[8], got[9], got[10], got[11], got[12], got[13], got[14], got[15])
+				t.Errorf("want:  %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X\n", tv[16], tv[17], tv[18], tv[19], tv[20], tv[21], tv[22], tv[23], tv[24], tv[25], tv[26], tv[27], tv[28], tv[29], tv[30], tv[31])
+				t.Errorf("got:   %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X\n", got[16], got[17], got[18], got[19], got[20], got[21], got[22], got[23], got[24], got[25], got[26], got[27], got[28], got[29], got[30], got[31])
+				t.Errorf("want:  %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X\n", tv[32], tv[33], tv[34], tv[35], tv[36], tv[37], tv[38], tv[39], tv[40], tv[41], tv[42], tv[43], tv[44], tv[45], tv[46], tv[47])
+				t.Errorf("got:   %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X\n", got[32], got[33], got[34], got[35], got[36], got[37], got[38], got[39], got[40], got[41], got[42], got[43], got[44], got[45], got[46], got[47])
+				t.Errorf("want:  %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X\n", tv[48], tv[49], tv[50], tv[51], tv[52], tv[53], tv[54], tv[55], tv[56], tv[57], tv[58], tv[59], tv[60], tv[61], tv[62], tv[63])
+				t.Errorf("got:   %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X\n", got[48], got[49], got[50], got[51], got[52], got[53], got[54], got[55], got[56], got[57], got[58], got[59], got[60], got[61], got[62], got[63])
+			}
 		}
 	}
 
@@ -162,10 +156,56 @@ func TestTriviumTestVectors(t *testing.T) {
 	}
 }
 
+func TestTriviumSWAR(t *testing.T) {
+	var key = [10]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	var IV = [10]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	var trivium = NewTrivium(key, IV)
+	var triviumSWAR = NewTrivium(key, IV)
+	var totalBitsToCompare uint = 4 * 288
+	var maxSWARwidth uint = 32
+	for SWARwidth := uint(1); SWARwidth <= maxSWARwidth; SWARwidth++ {
+		for i := uint(0); i < totalBitsToCompare; {
+			SWARbits := triviumSWAR.NextBits(SWARwidth)
+			for j := uint(0); j < SWARwidth; j++ {
+				i++
+				bit := trivium.NextBit()
+				if bit != (SWARbits>>j)&1 {
+					t.Errorf(" for SWARwidth %d bits at %d don't match %d != %d", SWARwidth, i, bit, (SWARbits>>j)&1)
+				}
+			}
+		}
+	}
+}
+
+func TestTriviumBytes(t *testing.T) {
+	var key = [10]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	var IV = [10]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	var trivium = NewTrivium(key, IV)
+	var triviumBytes = NewTrivium(key, IV)
+	var totalBytesToCompare uint = 4 * 288
+	var maxBytes uint = 4
+	for bytes := uint(1); bytes <= maxBytes; bytes++ {
+		for i := uint(0); i < totalBytesToCompare; {
+			KeyBytes := triviumBytes.NextBytes(bytes)
+			for j := uint(0); j < bytes; j++ {
+				i++
+				KeyByte := KeyBytes[j]
+				for k := uint(0); k < 8; k++ {
+					bit := byte(trivium.NextBit())
+					if bit != (KeyByte>>k)&1 {
+						t.Errorf("Bytes in increments of %d at %d don't match %d != %d", bytes, i, bit, (KeyByte>>k)&1)
+					}
+				}
+			}
+		}
+	}
+}
+
 var testBit uint32
 var testByte byte
+var testBytes []byte
 
-func BenchmarkTriviumBits(b *testing.B) {
+func BenchmarkTriviumBit(b *testing.B) {
 	var key = [10]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 	var IV = [10]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 	var trivium = NewTrivium(key, IV)
@@ -179,7 +219,7 @@ func BenchmarkTriviumBits(b *testing.B) {
 	} // to avoid optimizing out the loop entirely
 }
 
-func BenchmarkTriviumBytes(b *testing.B) {
+func BenchmarkTriviumByte(b *testing.B) {
 	var key = [10]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 	var IV = [10]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 	var trivium = NewTrivium(key, IV)
@@ -187,6 +227,20 @@ func BenchmarkTriviumBytes(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		testByte = trivium.NextByte()
+	}
+	if trivium.NextBit() == 1 {
+		testByte = 1
+	} // to avoid optimizing out the loop entirely
+}
+
+func BenchmarkTriviumBytes(b *testing.B) {
+	var key = [10]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	var IV = [10]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	var trivium = NewTrivium(key, IV)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		testBytes = trivium.NextBytes(4)
 	}
 	if trivium.NextBit() == 1 {
 		testByte = 1


### PR DESCRIPTION
32-bit SWAR calculation working
3x slower per bit but same speed per byte as per bit
4 bytes adds ~60% casting overhead